### PR TITLE
Add area effect pulse mechanics and extend automation tests

### DIFF
--- a/Source/PoE2Framework/Private/AbilitySystem/Actors/PoE2AreaEffectBase.cpp
+++ b/Source/PoE2Framework/Private/AbilitySystem/Actors/PoE2AreaEffectBase.cpp
@@ -1,9 +1,196 @@
 #include "AbilitySystem/Actors/PoE2AreaEffectBase.h"
+#include "AbilitySystemComponent.h"
+#include "AbilitySystemBlueprintLibrary.h"
+#include "Components/SphereComponent.h"
+#include "Core/PoE2Tags.h"
+#include "Net/UnrealNetwork.h"
+#include "UObject/UObjectGlobals.h"
 
 APoE2AreaEffectBase::APoE2AreaEffectBase()
 {
     PrimaryActorTick.bCanEverTick = true;
+    SetActorTickEnabled(false);
     bReplicates = true;
-    
-    // TODO: Initialize area effect properties
+
+    AreaComponent = CreateDefaultSubobject<USphereComponent>(TEXT("AreaComponent"));
+    SetRootComponent(AreaComponent);
+    AreaComponent->InitSphereRadius(100.0f);
+    AreaComponent->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+    AreaComponent->SetCollisionResponseToAllChannels(ECR_Overlap);
+    AreaComponent->SetGenerateOverlapEvents(true);
+
+    DamageTickInterval = 1.0f;
+    TimeSinceLastPulse = 0.0f;
+}
+
+const FName APoE2AreaEffectBase::AreaTickIntervalKey(TEXT("Area.TickInterval"));
+
+void APoE2AreaEffectBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(APoE2AreaEffectBase, CurrentSpec);
+}
+
+void APoE2AreaEffectBase::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void APoE2AreaEffectBase::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    if (HasAuthority())
+    {
+        TimeSinceLastPulse += DeltaSeconds;
+        if (TimeSinceLastPulse >= DamageTickInterval && DamageTickInterval > KINDA_SMALL_NUMBER)
+        {
+            TimeSinceLastPulse -= DamageTickInterval;
+            HandleAreaPulse();
+        }
+    }
+
+    for (const TScriptInterface<IMechanicHandler>& Handler : ActiveHandlers)
+    {
+        if (Handler)
+        {
+            IMechanicHandler::Execute_OnTick(Handler.GetObject(), this, DeltaSeconds, CurrentSpec);
+        }
+    }
+}
+
+void APoE2AreaEffectBase::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    for (const TScriptInterface<IMechanicHandler>& Handler : ActiveHandlers)
+    {
+        if (Handler)
+        {
+            IMechanicHandler::Execute_OnEnd(Handler.GetObject(), this, CurrentSpec);
+        }
+    }
+    ActiveHandlers.Reset();
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void APoE2AreaEffectBase::InitFromSpec(const FSkillSpec& InSpec, UAbilitySystemComponent* InOwnerASC, const TArray<TScriptInterface<IMechanicHandler>>& HandlerPrototypes)
+{
+    CurrentSpec = InSpec;
+    OwnerASC = InOwnerASC;
+
+    DamageTickInterval = FMath::Max(0.05f, CurrentSpec.GetCustomParam(AreaTickIntervalKey, 1.0f));
+    TimeSinceLastPulse = DamageTickInterval;
+
+    ActiveHandlers.Reset();
+    for (const TScriptInterface<IMechanicHandler>& HandlerPrototype : HandlerPrototypes)
+    {
+        UObject* PrototypeObject = HandlerPrototype.GetObject();
+        if (!PrototypeObject)
+        {
+            continue;
+        }
+
+        UObject* DuplicatedObject = DuplicateObject(PrototypeObject, this);
+        if (!DuplicatedObject)
+        {
+            continue;
+        }
+
+        TScriptInterface<IMechanicHandler> HandlerInstance;
+        HandlerInstance.SetObject(DuplicatedObject);
+        HandlerInstance.SetInterface(Cast<IMechanicHandler>(DuplicatedObject));
+
+        if (!HandlerInstance.GetInterface())
+        {
+            continue;
+        }
+
+        ActiveHandlers.Add(HandlerInstance);
+        IMechanicHandler::Execute_OnSpawn(DuplicatedObject, this, CurrentSpec);
+    }
+
+    if (CurrentSpec.Lifetime > 0.0f)
+    {
+        SetLifeSpan(CurrentSpec.Lifetime);
+    }
+
+    if (AreaComponent)
+    {
+        const float Radius = (CurrentSpec.AreaRadius > 0.0f) ? CurrentSpec.AreaRadius : AreaComponent->GetUnscaledSphereRadius();
+        AreaComponent->SetSphereRadius(Radius, true);
+        AreaComponent->UpdateOverlaps();
+    }
+
+    const bool bShouldTick = (ActiveHandlers.Num() > 0) || (CurrentSpec.DamageEffectClass != nullptr);
+    SetActorTickEnabled(bShouldTick);
+
+    if (HasAuthority() && CurrentSpec.DamageEffectClass)
+    {
+        HandleAreaPulse();
+        TimeSinceLastPulse = 0.0f;
+    }
+}
+
+int32 APoE2AreaEffectBase::GetActiveHandlerCount() const
+{
+    return ActiveHandlers.Num();
+}
+
+void APoE2AreaEffectBase::HandleAreaPulse()
+{
+    if (!AreaComponent)
+    {
+        return;
+    }
+
+    TArray<AActor*> OverlappingActors;
+    AreaComponent->GetOverlappingActors(OverlappingActors);
+
+    for (AActor* Actor : OverlappingActors)
+    {
+        if (!Actor || Actor == this || Actor == GetOwner())
+        {
+            continue;
+        }
+
+        ApplyEffectToActor(Actor);
+    }
+}
+
+void APoE2AreaEffectBase::ApplyEffectToActor(AActor* TargetActor)
+{
+    if (!TargetActor)
+    {
+        return;
+    }
+
+    if (OwnerASC && CurrentSpec.DamageEffectClass)
+    {
+        if (UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(TargetActor))
+        {
+            FGameplayEffectContextHandle ContextHandle = OwnerASC->MakeEffectContext();
+            ContextHandle.AddSourceObject(this);
+
+            FGameplayEffectSpecHandle SpecHandle = OwnerASC->MakeOutgoingSpec(CurrentSpec.DamageEffectClass, 1.0f, ContextHandle);
+
+            if (SpecHandle.IsValid())
+            {
+                SpecHandle.Data->SetSetByCallerMagnitude(FPoE2Tags::Get().Data_Damage, CurrentSpec.FinalDamage);
+                OwnerASC->ApplyGameplayEffectSpecToTarget(*SpecHandle.Data.Get(), TargetASC);
+            }
+        }
+    }
+
+    FHitResult DummyHit;
+    DummyHit.Location = TargetActor->GetActorLocation();
+    DummyHit.ImpactPoint = DummyHit.Location;
+
+    for (const TScriptInterface<IMechanicHandler>& Handler : ActiveHandlers)
+    {
+        if (Handler)
+        {
+            IMechanicHandler::Execute_OnHit(Handler.GetObject(), this, TargetActor, DummyHit, CurrentSpec);
+        }
+    }
 }

--- a/Source/PoE2Framework/Private/AbilitySystem/Actors/PoE2MinionBase.cpp
+++ b/Source/PoE2Framework/Private/AbilitySystem/Actors/PoE2MinionBase.cpp
@@ -1,9 +1,96 @@
 #include "AbilitySystem/Actors/PoE2MinionBase.h"
+#include "AbilitySystemComponent.h"
+#include "Net/UnrealNetwork.h"
+#include "UObject/UObjectGlobals.h"
 
 APoE2MinionBase::APoE2MinionBase()
 {
     PrimaryActorTick.bCanEverTick = true;
+    SetActorTickEnabled(false);
     bReplicates = true;
-    
-    // TODO: Initialize minion properties
+}
+
+void APoE2MinionBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+    DOREPLIFETIME(APoE2MinionBase, CurrentSpec);
+}
+
+void APoE2MinionBase::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void APoE2MinionBase::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    for (const TScriptInterface<IMechanicHandler>& Handler : ActiveHandlers)
+    {
+        if (Handler)
+        {
+            IMechanicHandler::Execute_OnTick(Handler.GetObject(), this, DeltaSeconds, CurrentSpec);
+        }
+    }
+}
+
+void APoE2MinionBase::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    for (const TScriptInterface<IMechanicHandler>& Handler : ActiveHandlers)
+    {
+        if (Handler)
+        {
+            IMechanicHandler::Execute_OnEnd(Handler.GetObject(), this, CurrentSpec);
+        }
+    }
+    ActiveHandlers.Reset();
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void APoE2MinionBase::InitFromSpec(const FSkillSpec& InSpec, UAbilitySystemComponent* InOwnerASC, const TArray<TScriptInterface<IMechanicHandler>>& HandlerPrototypes)
+{
+    CurrentSpec = InSpec;
+    OwnerASC = InOwnerASC;
+
+    ActiveHandlers.Reset();
+    for (const TScriptInterface<IMechanicHandler>& HandlerPrototype : HandlerPrototypes)
+    {
+        UObject* PrototypeObject = HandlerPrototype.GetObject();
+        if (!PrototypeObject)
+        {
+            continue;
+        }
+
+        UObject* DuplicatedObject = DuplicateObject(PrototypeObject, this);
+        if (!DuplicatedObject)
+        {
+            continue;
+        }
+
+        TScriptInterface<IMechanicHandler> HandlerInstance;
+        HandlerInstance.SetObject(DuplicatedObject);
+        HandlerInstance.SetInterface(Cast<IMechanicHandler>(DuplicatedObject));
+
+        if (!HandlerInstance.GetInterface())
+        {
+            continue;
+        }
+
+        ActiveHandlers.Add(HandlerInstance);
+        IMechanicHandler::Execute_OnSpawn(DuplicatedObject, this, CurrentSpec);
+    }
+
+    if (CurrentSpec.Lifetime > 0.0f)
+    {
+        SetLifeSpan(CurrentSpec.Lifetime);
+    }
+
+    SetActorTickEnabled(ActiveHandlers.Num() > 0);
+}
+
+int32 APoE2MinionBase::GetActiveHandlerCount() const
+{
+    return ActiveHandlers.Num();
 }

--- a/Source/PoE2Framework/Public/AbilitySystem/Actors/PoE2AreaEffectBase.h
+++ b/Source/PoE2Framework/Public/AbilitySystem/Actors/PoE2AreaEffectBase.h
@@ -2,7 +2,12 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "Spec/SkillSpec.h"
+#include "AbilitySystem/Handlers/MechanicHandler.h"
 #include "PoE2AreaEffectBase.generated.h"
+
+class UAbilitySystemComponent;
+class USphereComponent;
 
 UCLASS(BlueprintType)
 class POE2FRAMEWORK_API APoE2AreaEffectBase : public AActor
@@ -12,6 +17,40 @@ class POE2FRAMEWORK_API APoE2AreaEffectBase : public AActor
 public:
     APoE2AreaEffectBase();
 
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    UFUNCTION(BlueprintCallable, Category = "AreaEffect")
+    virtual void InitFromSpec(const FSkillSpec& InSpec, UAbilitySystemComponent* InOwnerASC, const TArray<TScriptInterface<IMechanicHandler>>& HandlerPrototypes);
+
+    UFUNCTION(BlueprintPure, Category = "AreaEffect|Mechanics")
+    int32 GetActiveHandlerCount() const;
+
 protected:
-    // TODO: Define area effect properties with bReplicates = true
+    UFUNCTION(BlueprintCallable, Category = "AreaEffect", meta=(BlueprintProtected="true"))
+    void HandleAreaPulse();
+
+    void ApplyEffectToActor(AActor* TargetActor);
+
+protected:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "AreaEffect")
+    TObjectPtr<USphereComponent> AreaComponent;
+
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Replicated, Category = "AreaEffect")
+    FSkillSpec CurrentSpec;
+
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "AreaEffect")
+    TObjectPtr<UAbilitySystemComponent> OwnerASC;
+
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "AreaEffect")
+    TArray<TScriptInterface<IMechanicHandler>> ActiveHandlers;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "AreaEffect")
+    float DamageTickInterval;
+
+    float TimeSinceLastPulse;
+
+    static const FName AreaTickIntervalKey;
 };

--- a/Source/PoE2Framework/Public/AbilitySystem/Actors/PoE2MinionBase.h
+++ b/Source/PoE2Framework/Public/AbilitySystem/Actors/PoE2MinionBase.h
@@ -2,7 +2,11 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Pawn.h"
+#include "Spec/SkillSpec.h"
+#include "AbilitySystem/Handlers/MechanicHandler.h"
 #include "PoE2MinionBase.generated.h"
+
+class UAbilitySystemComponent;
 
 UCLASS(BlueprintType)
 class POE2FRAMEWORK_API APoE2MinionBase : public APawn
@@ -12,6 +16,24 @@ class POE2FRAMEWORK_API APoE2MinionBase : public APawn
 public:
     APoE2MinionBase();
 
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    UFUNCTION(BlueprintCallable, Category = "Minion")
+    virtual void InitFromSpec(const FSkillSpec& InSpec, UAbilitySystemComponent* InOwnerASC, const TArray<TScriptInterface<IMechanicHandler>>& HandlerPrototypes);
+
+    UFUNCTION(BlueprintPure, Category = "Minion|Mechanics")
+    int32 GetActiveHandlerCount() const;
+
 protected:
-    // TODO: Define minion properties with bReplicates = true
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Replicated, Category = "Minion")
+    FSkillSpec CurrentSpec;
+
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Minion")
+    TObjectPtr<UAbilitySystemComponent> OwnerASC;
+
+    UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Minion")
+    TArray<TScriptInterface<IMechanicHandler>> ActiveHandlers;
 };

--- a/Source/PoE2Framework/Public/AbilitySystem/GA_SkillBase.h
+++ b/Source/PoE2Framework/Public/AbilitySystem/GA_SkillBase.h
@@ -32,7 +32,9 @@ class POE2FRAMEWORK_API UGA_SkillBase : public UGameplayAbility
     GENERATED_BODY()
 
 public:
-    /** 
+    UGA_SkillBase();
+
+    /**
      * The main entry point for skill execution.
      * Expects TriggerEventData to contain the necessary context, such as the SkillDataAsset.
      */
@@ -116,6 +118,11 @@ public:
      */
     UFUNCTION(BlueprintImplementableEvent, Category = "Skill", meta = (DisplayName = "PerformSpawn"))
     void K2_PerformSpawn(const FSkillSpec& SkillSpec);
+
+protected:
+    /** When true (default), ExecuteSkillEffects will be invoked automatically if no Blueprint overrides PerformSpawn. */
+    UPROPERTY(EditDefaultsOnly, Category = "Skill")
+    bool bAutoExecuteSkillEffects;
 
 private:
     /** Animation callback for when the cast montage completes successfully. */


### PR DESCRIPTION
## Summary
- add replicated sphere collision and pulse handling to `APoE2AreaEffectBase` so area skills can apply damage and trigger mechanics over time
- replicate the skill specification to minion actors to keep clients in sync with the server
- extend automation tests with helper actors and a new area-effect spec to cover the new pulse behavior

## Testing
- not run (Unreal automation tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc0183c51c832a83bd085567f8194d